### PR TITLE
Big Fix: added \r\n match for windows

### DIFF
--- a/dictionary/lib/dictionary/word_list.ex
+++ b/dictionary/lib/dictionary/word_list.ex
@@ -9,6 +9,6 @@ defmodule Dictionary.WordList do
     "../../assets/words.txt"
     |> Path.expand(__DIR__)
     |> File.read!()
-    |> String.split(~r/\n/)
+    |> String.split(~r/\r\n|\n/)
   end
 end


### PR DESCRIPTION
not an assignment submission, but I just wanted to make the dictionary word list work on windows machines